### PR TITLE
Add Core Darwin Configuration with macOS Settings

### DIFF
--- a/darwin/default.nix
+++ b/darwin/default.nix
@@ -1,1 +1,65 @@
-{ ... }: {}
+{
+  pkgs,
+  ...
+}:
+{
+  fonts.packages = with pkgs; [
+    nerd-fonts.victor-mono
+  ];
+
+  homebrew = {
+    enable = true;
+    onActivation = {
+      autoUpdate = false;
+      cleanup = "none";
+      upgrade = false;
+    };
+    casks = [
+      "ghostty"
+      "gimp"
+      "inkscape"
+      "raycast"
+      "spotify"
+    ];
+  };
+
+  system.defaults = {
+    CustomUserPreferences = {
+      "com.apple.screencapture" = {
+        location = "~/Pictures"; # Where Screen Captures Will Save To
+      };
+      "com.apple.symbolichotkeys" = {
+        AppleSymbolicHotKeys = {
+          "60".enabled = false; # Show Spotlight Search (Ctrl+Space)
+          "61".enabled = false; # Show Finder Search (Ctrl+Opt+Space)
+          "64".enabled = false; # Spotlight Menu (Cmd+Space)
+        };
+      };
+    };
+    dock = {
+      autohide = true;
+      mru-spaces = false;
+      magnification = false;
+      minimize-to-application = true;
+      show-recents = false;
+    };
+    finder = {
+      AppleShowAllExtensions = true;
+      FXPreferredViewStyle = "clmv";
+      ShowHardDrivesOnDesktop = false;
+      ShowStatusBar = false;
+      ShowPathbar = true;
+    };
+    NSGlobalDomain = {
+      AppleInterfaceStyle = "Dark";
+      AppleShowAllExtensions = true;
+      NSAutomaticCapitalizationEnabled = false;
+      NSAutomaticPeriodSubstitutionEnabled = false;
+      "com.apple.trackpad.forceClick" = true;
+    };
+    trackpad = {
+      Clicking = false; # Tap to Click
+      TrackpadThreeFingerDrag = false;
+    };
+  };
+}


### PR DESCRIPTION
## 🎯 What We're Doing

We're adding comprehensive Darwin configuration management to establish proper macOS system configuration through Nix. This work implements the foundational system management layer for the personal Nix configuration.

## 💡 Why This Matters

This change establishes declarative management of macOS system settings, preventing configuration drift and ensuring reproducible system state across rebuilds. Without proper system configuration management, macOS preferences would remain scattered across GUI settings and require manual reconfiguration after system changes.

## ⚠️ Review Checklist

- 🔍 **macOS Settings**: Verify system preferences are appropriate for personal use → Incorrect settings could impact daily workflow
- 🔍 **Homebrew Casks**: Check that GUI applications match intended setup → Missing or wrong applications would break expected toolchain
- 🔍 **Module Structure**: Ensure proper separation of concerns between system and user configs → Poor organization would complicate future maintenance

## 🔧 Technical Approach

Chose nix-darwin over manual configuration because it provides version control and rollback capabilities for system state. The configuration separates system-level packages (managed by Darwin) from user-level dotfiles (managed by Home Manager), establishing clear boundaries for future configuration changes.

Added Homebrew cask integration to handle GUI applications that aren't available in nixpkgs, accepting the hybrid approach to maximize application availability while maintaining declarative configuration where possible.