### PR TITLE
Extract Universal Glow Markdown Viewer to Core Architecture

### DIFF
--- a/home-manager/default.nix
+++ b/home-manager/default.nix
@@ -12,6 +12,7 @@
     ./gh
     ./ghostty
     ./git
+    ./glow
     ./gnupg
     ./jq
     ./lsd

--- a/home-manager/glow/default.nix
+++ b/home-manager/glow/default.nix
@@ -1,0 +1,11 @@
+{
+  pkgs,
+  ...
+}:
+{
+  home.packages = with pkgs; [
+    glow
+  ];
+
+  home.file."Library/Preferences/glow/glow.yml".source = ./glow.yml;
+}

--- a/home-manager/glow/glow.yml
+++ b/home-manager/glow/glow.yml
@@ -1,0 +1,6 @@
+# Enable mouse wheel support in TUI mode
+mouse: true
+# Use pager by default for viewing markdown
+pager: true
+# Use full terminal width (0 = dynamic width)
+width: 0


### PR DESCRIPTION
## 🎯 What We're Doing

We're extracting the glow markdown viewer configuration from the work repository to the universal core architecture as Phase 10 of our modular configuration system. This work continues the systematic separation of universal tools from Shopify-specific configuration.

## 💡 Why This Matters

Without this extraction, the glow markdown viewer remains trapped in Shopify-specific configuration, preventing reuse across personal and other business environments. Markdown viewing is a universal development activity that belongs in core infrastructure, unlike tools such as Raycast which are genuinely Shopify-specific.

This change enables consistent markdown viewing experience across all development environments while maintaining the clean separation between universal and company-specific tools.

## ⚠️ Review Checklist

- 🔍 **Module Structure**: Verify glow module follows core.nix patterns → Ensures consistency with existing modules
- 🔍 **Configuration Values**: Check that mouse, pager, and width settings are universally appropriate → Prevents environment-specific assumptions
- 🔍 **File Placement**: Confirm glow.yml goes to correct Library/Preferences location → Ensures glow finds its configuration

## 🔧 Technical Approach

**Module Architecture**: Created standalone glow module with package installation and configuration file management, following the established pattern of other core modules.

**Configuration Philosophy**: Chose universally beneficial defaults (mouse support, pager mode, dynamic width) over opinionated settings, ensuring the configuration works well across different development workflows.

**Separation Logic**: Extracted glow while leaving Raycast in work repository, demonstrating clear decision-making about universal vs. company-specific tools based on actual usage patterns.