### PR TITLE
Add Universal Session Path and Home-Manager Enable to Core Configuration

### DIFF
--- a/home-manager/default.nix
+++ b/home-manager/default.nix
@@ -29,4 +29,14 @@
     ./zoxide
     ./zsh
   ];
+
+  home = {
+    sessionPath = [
+      "$HOME/.local/bin"
+    ];
+  };
+
+  programs = {
+    home-manager.enable = true;
+  };
 }


### PR DESCRIPTION
## 🎯 What We're Doing

We're moving two fundamental settings—sessionPath for ~/.local/bin and home-manager.enable—from specific configurations into the core home-manager module. This establishes baseline functionality that both personal and work environments can build upon.

## 💡 Why This Matters

Currently, every environment setup has to remember to include these essential settings. Without sessionPath for ~/.local/bin, locally installed tools and scripts become inaccessible. Without home-manager.enable, the tool can't manage itself in new environments.

These omissions create friction during environment setup and force duplicate configuration across different contexts. This change eliminates that repetition by making these settings universally available.

## ⚠️ Review Checklist

- 🔍 **Session Path Addition**: Verify ~/.local/bin is correctly added to PATH → Essential for local binary access across all environments
- 🔍 **Home-Manager Self-Management**: Confirm home-manager.enable is properly set → Required for the tool to function in any environment
- 🔍 **Scope Appropriateness**: Check that these settings truly belong in core → They provide baseline functionality needed everywhere

## 🔧 Technical Approach

Chose to add these settings directly to the core home-manager/default.nix rather than creating separate modules because:

- They're single-line configurations that don't warrant their own files
- They represent fundamental baseline settings rather than feature-specific configurations  
- They align with the core.nix mission of providing universal, reusable primitives

This establishes a foundation that specific environments can extend without having to redeclare these essentials.