### PR TITLE
feat(nix-darwin): enhance system defaults with comprehensive macOS settings

### DIFF
--- a/nix-darwin/system/default.nix
+++ b/nix-darwin/system/default.nix
@@ -2,9 +2,6 @@
 {
   system.defaults = {
     CustomUserPreferences = {
-      "com.apple.screencapture" = {
-        location = "~/Pictures"; # Where Screen Captures Will Save To
-      };
       "com.apple.symbolichotkeys" = {
         AppleSymbolicHotKeys = {
           "60".enabled = false; # Show Spotlight Search (Ctrl+Space)
@@ -18,21 +15,39 @@
       mru-spaces = false;
       magnification = false;
       minimize-to-application = true;
+      orientation = "bottom";
       show-recents = false;
+      tilesize = 64;
+      wvous-bl-corner = 4; # Show Desktop
+      wvous-br-corner = 12; # Notification Centre
     };
     finder = {
       AppleShowAllExtensions = true;
       FXPreferredViewStyle = "clmv";
+      NewWindowTarget = "Home";
       ShowHardDrivesOnDesktop = false;
       ShowStatusBar = false;
       ShowPathbar = true;
+      _FXSortFoldersFirst = true;
+    };
+    hitoolbox.AppleFnUsageType = "Change Input Source";
+    loginwindow.GuestEnabled = false;
+    menuExtraClock = {
+      Show24Hours = true;
+      ShowDate = 0; # When Space Allows
     };
     NSGlobalDomain = {
+      AppleICUForce24HourTime = true;
       AppleInterfaceStyle = "Dark";
       AppleShowAllExtensions = true;
+      KeyRepeat = 2;
       NSAutomaticCapitalizationEnabled = false;
       NSAutomaticPeriodSubstitutionEnabled = false;
       "com.apple.trackpad.forceClick" = true;
+    };
+    screencapture = {
+      location = "~/Pictures";
+      target = "clipboard";
     };
     trackpad = {
       Clicking = false; # Tap to Click
@@ -40,4 +55,3 @@
     };
   };
 }
-


### PR DESCRIPTION
## Summary
- Enhanced dock configuration with orientation, tilesize, and hot corner settings
- Improved finder defaults with home directory target and folder sorting
- Added comprehensive menu bar clock configuration for 24-hour format
- Configured keyboard settings including repeat rate and Fn key behavior
- Updated screencapture settings to default to clipboard
- Cleaned up redundant preference configurations

## Test plan
- [ ] Verify dock appears at bottom with correct tile size
- [ ] Test hot corners functionality (bottom-left: Show Desktop, bottom-right: Notification Centre)
- [ ] Confirm finder opens to home directory and sorts folders first
- [ ] Check menu bar shows 24-hour time format
- [ ] Validate keyboard repeat rate and Fn key behavior
- [ ] Test screencapture saves to clipboard by default

🤖 Generated with [Claude Code](https://claude.ai/code)