### PR TITLE
Fix Comma Placement in Claude Statusline Token Display

### DIFF
--- a/home-manager/claude/claude-statusline.rb
+++ b/home-manager/claude/claude-statusline.rb
@@ -280,9 +280,9 @@ module Claude
 
         content = renderer.format_composite(
           {icon: :database, text: '', color: :cyan},
-          {icon: severity_icon, text: "#{token_metrics.context_percentage}%", color: severity_color}
+          {icon: severity_icon, text: "#{token_metrics.context_percentage}%", color: severity_color},
           {icon: :pipe, text: '', color: :dark_blue},
-          {icon: :download, text: format_count(token_metrics.input_tokens), color: :green},
+          {icon: :download, text: format_count(token_metrics.input_tokens), color: :green}
         )
 
         Domain::Segment.new(content: content)


### PR DESCRIPTION
## 🎯 What We're Doing

We're fixing a syntax error in the Claude statusline's token metrics display to prevent execution failures. This work addresses a simple but critical comma placement bug that would break the status display.

## 💡 Why This Matters

Without this change, the statusline token metrics display would fail to execute due to incorrect Ruby method call syntax, causing the entire statusline to break and preventing users from seeing their Claude conversation token usage metrics.

This change ensures users can reliably monitor their token consumption and context window usage, which is essential for managing Claude conversation costs and understanding when context limits might be reached.

## ⚠️ Review Checklist

- 🔍 **Method Call Syntax**: Verify the `format_composite` call has proper comma placement → Any syntax errors would break the entire statusline
- 🔍 **Parameter Count**: Confirm all four parameters are properly separated → Missing or extra commas would cause argument mismatch errors

## 🔧 Technical Approach

Fixed two comma placement issues in the `format_composite` method call:
1. Added missing comma after the `severity_color` parameter
2. Removed unnecessary trailing comma after the last parameter

This follows standard Ruby method call syntax where parameters are comma-separated with no trailing comma after the final argument.