### PR TITLE
Fix Neovim Terminal Mode Navigation Reliability

### DIFF
--- a/home-manager/neovim/init.lua
+++ b/home-manager/neovim/init.lua
@@ -202,19 +202,19 @@ vim.api.nvim_create_autocmd('TermOpen', {
 
 -- Window Navigation (Alt+Shift+Arrow)
 vim.keymap.set('n', '<M-S-Left>', '<C-w>h', { desc = 'Go to left window' })
-vim.keymap.set('t', '<M-S-Left>', '<C-\\><C-o><C-w>h', { desc = 'Go to left window from terminal' })
+vim.keymap.set('t', '<M-S-Left>', '<C-\\><C-n><C-w>h', { desc = 'Go to left window from terminal' })
 vim.keymap.set('n', '<M-S-Right>', '<C-w>l', { desc = 'Go to right window' })
-vim.keymap.set('t', '<M-S-Right>', '<C-\\><C-o><C-w>l', { desc = 'Go to right window from terminal' })
+vim.keymap.set('t', '<M-S-Right>', '<C-\\><C-n><C-w>l', { desc = 'Go to right window from terminal' })
 vim.keymap.set('n', '<M-S-Up>', '<C-w>k', { desc = 'Go to upper window' })
-vim.keymap.set('t', '<M-S-Up>', '<C-\\><C-o><C-w>k', { desc = 'Go to upper window from terminal' })
+vim.keymap.set('t', '<M-S-Up>', '<C-\\><C-n><C-w>k', { desc = 'Go to upper window from terminal' })
 vim.keymap.set('n', '<M-S-Down>', '<C-w>j', { desc = 'Go to lower window' })
-vim.keymap.set('t', '<M-S-Down>', '<C-\\><C-o><C-w>j', { desc = 'Go to lower window from terminal' })
+vim.keymap.set('t', '<M-S-Down>', '<C-\\><C-n><C-w>j', { desc = 'Go to lower window from terminal' })
 
 -- Tab Navigation (Control+Arrow)
 vim.keymap.set('n', '<C-Left>', 'gT', { desc = 'Previous tab' })
-vim.keymap.set('t', '<C-Left>', '<C-\\><C-o>gT', { desc = 'Previous tab from terminal' })
+vim.keymap.set('t', '<C-Left>', '<C-\\><C-n>gT', { desc = 'Previous tab from terminal' })
 vim.keymap.set('n', '<C-Right>', 'gt', { desc = 'Next tab' })
-vim.keymap.set('t', '<C-Right>', '<C-\\><C-o>gt', { desc = 'Previous tab from terminal' })
+vim.keymap.set('t', '<C-Right>', '<C-\\><C-n>gt', { desc = 'Previous tab from terminal' })
 
 -- Terminal mode mappings
 vim.keymap.set('t', '<S-Esc>', '<C-\\><C-n>', { desc = 'Exit terminal mode' })


### PR DESCRIPTION
## 🎯 What We're Doing

We're improving terminal mode navigation reliability in Neovim by replacing `<C-\><C-o>` with `<C-\><C-n>` in terminal mode keybindings. This change addresses inconsistent behavior when navigating between windows and tabs from terminal mode.

## 💡 Why This Matters

Without this change, navigation from terminal mode can behave unpredictably because `<C-\><C-o>` only temporarily enters normal mode before returning to terminal mode. This creates a race condition where navigation commands may not execute reliably, leading to frustrating user experiences when switching between terminal and editor windows.

This change ensures consistent navigation behavior across all scenarios, making the terminal integration more dependable for daily development workflows.

## ⚠️ Review Checklist

- 🔍 **Keybinding Changes**: All 6 terminal mode navigation keybindings updated from `<C-o>` to `<C-n>` → Verify mapping consistency and that navigation works reliably from terminal mode
- 🔍 **Terminal Mode Exit**: Using `<C-n>` fully exits terminal mode before navigation → Test that users can navigate and return to terminal seamlessly
- 🔍 **Backward Compatibility**: Changes only affect terminal mode mappings → Confirm normal mode navigation remains unchanged

## 🔧 Technical Approach

Chose `<C-\><C-n>` over `<C-\><C-o>` because reliable state transitions matter more than staying in terminal mode. The `<C-n>` approach provides predictable behavior by fully exiting terminal mode before executing navigation commands, eliminating timing-dependent inconsistencies.

This trade-off accepts that users will need to re-enter terminal mode after navigation, but gains consistent and reliable navigation behavior that works every time.