### PR TITLE
Fix Terminal Hook Race Condition to Prevent Exit Code Loss

### DIFF
--- a/home-manager/zsh/terminal.zsh
+++ b/home-manager/zsh/terminal.zsh
@@ -27,8 +27,14 @@ function _emit_working_directory() {
 
 # Register hooks in execution order
 # precmd: runs before each prompt is displayed
-precmd_functions+=(
+# CRITICAL: _emit_command_finished must be FIRST to capture exit code
+precmd_functions=(
   _emit_command_finished    # Must be first to capture exit code
+  ${precmd_functions[@]}    # Preserve existing functions
+)
+
+# Add remaining precmd hooks (order doesn't matter for these)
+precmd_functions+=(
   _emit_prompt_start        # Mark prompt beginning
   _emit_working_directory   # Update terminal's CWD
 )


### PR DESCRIPTION
## 🎯 What We're Doing

We're fixing a critical race condition in ZSH terminal hooks where exit codes could be lost before terminal integration captures them. This work addresses a reliability issue where terminal features dependent on accurate exit codes would fail intermittently.

## 💡 Why This Matters

Without this change, the `_emit_command_finished` function could run after other precmd hooks that modify or consume `$?`, causing the terminal integration to receive incorrect exit codes. This breaks features like status indicators, command completion notifications, and error handling workflows that depend on accurate command results.

This change ensures reliable terminal integration by guaranteeing exit code capture happens first, which enables consistent status reporting and prevents silent failures in terminal workflows.

## ⚠️ Review Checklist

- 🔍 **Hook Ordering**: The array assignment preserves existing functions while ensuring `_emit_command_finished` is first → Critical for exit code reliability
- 🔍 **Array Expansion**: The `${precmd_functions[@]}` syntax correctly preserves all existing hooks → Prevents breaking other ZSH functionality  
- 🔍 **Function Preservation**: Existing precmd functions are maintained and appended after our critical hook → No loss of existing terminal features

## 🔧 Technical Approach

Chose explicit array assignment with preservation over simple append because ZSH's `precmd_functions` execution order is critical for exit code accuracy. The race condition occurred when other hooks ran first and consumed `$?` before our terminal integration could capture it.

Accepting slightly more complex syntax to gain guaranteed execution order, which matters because terminal integration features silently fail when exit codes are incorrect rather than producing obvious errors.