### PR TITLE
fix: improve statusline model icon compatibility across terminals

### DIFF
--- a/home-manager/claude/claude-statusline.rb
+++ b/home-manager/claude/claude-statusline.rb
@@ -142,7 +142,7 @@ module Claude
       class ANSITerminalRenderer
         ICONS = {
           folder: "\uF07B",
-          model: "\uF5DC",
+          model: "\uF2DB",
           database: "\uF1C0",
           download: "\uF019",
           upload: "\uF093",


### PR DESCRIPTION
## Summary
- Replace robot icon (\uF5DC) with chip icon (\uF2DB) in Claude statusline script
- Improves display compatibility between Ghostty and Warp terminals using Nerd Fonts

## Test plan
- [x] Verify chip icon displays correctly in Warp terminal
- [x] Confirm icon still displays correctly in Ghostty terminal

🤖 Generated with [Claude Code](https://claude.ai/code)