### PR TITLE
feat(neovim): add AI/Claude domain keybindings for claudecode.nvim

### DIFF
--- a/home-manager/neovim/KEYBINDINGS.md
+++ b/home-manager/neovim/KEYBINDINGS.md
@@ -50,6 +50,17 @@ The system uses **5 distinct input patterns**, each with a clear mental model:
 
 ### Primary Work Domains
 
+#### `<leader>a` - **AI/Claude** 🤖
+AI assistance and code collaboration operations.
+
+| Pattern | Key | Action | Description |
+|---------|-----|--------|-------------|
+| Picker | `<leader>aa` | AI focus terminal | Smart terminal focus/toggle |
+| Action | `<leader>as` | AI send context | Send buffer/visual selection to Claude |
+| Action | `<leader>ad` | AI diff accept | Accept Claude's proposed changes |
+| Action | `<leader>ar` | AI diff reject | Reject Claude's proposed changes |
+| Action | `<leader>am` | AI model select | Select Claude model (interactive) |
+
 #### `<leader>b` - **Buffers** 🔲
 Operations on open file buffers in memory.
 

--- a/home-manager/neovim/plugins/claudecode.lua
+++ b/home-manager/neovim/plugins/claudecode.lua
@@ -21,3 +21,35 @@ vim.api.nvim_create_autocmd('FocusGained', {
   desc = 'Check for file changes when Neovim gains focus',
 })
 
+-- ========================================
+-- AI/CLAUDE KEYBINDINGS
+-- ========================================
+
+-- Core Operations
+vim.keymap.set('n', '<leader>aa', '<cmd>ClaudeCodeFocus<CR>', { desc = 'AI focus terminal', silent = true })
+vim.keymap.set({ 'n', 'v' }, '<leader>as', '<cmd>ClaudeCodeSend<CR>', { desc = 'AI send context', silent = true })
+
+-- Diff Management
+vim.keymap.set('n', '<leader>ad', '<cmd>ClaudeCodeDiffAccept<CR>', { desc = 'AI diff accept', silent = true })
+vim.keymap.set('n', '<leader>ar', '<cmd>ClaudeCodeDiffDeny<CR>', { desc = 'AI diff reject', silent = true })
+
+-- Optional: Model Selection
+vim.keymap.set('n', '<leader>am', '<cmd>ClaudeCodeSelectModel<CR>', { desc = 'AI model select', silent = true })
+
+-- ========================================
+-- WHICH-KEY INTEGRATION
+-- ========================================
+
+-- Load which-key and register AI mappings
+local ok, which_key = pcall(require, 'which-key')
+if ok then
+  which_key.add({
+    -- Individual AI mappings with proper icons
+    { '<leader>aa', desc = 'AI focus terminal', icon = '🔎' },
+    { '<leader>as', desc = 'AI send context', icon = '📤', mode = { 'n', 'v' } },
+    { '<leader>ad', desc = 'AI diff accept', icon = '✅' },
+    { '<leader>ar', desc = 'AI diff reject', icon = '❌' },
+    { '<leader>am', desc = 'AI model select', icon = '⚙️' },
+  })
+end
+

--- a/home-manager/neovim/plugins/which-key.lua
+++ b/home-manager/neovim/plugins/which-key.lua
@@ -8,6 +8,7 @@ end
 -- Icon definitions using Unicode characters
 local icons = {
   -- Primary domain icons
+  ai = '🤖',
   buffer = '🔲',
   code = '💻',
   file = '📁',
@@ -99,6 +100,8 @@ which_key.add({
   -- ========================================
 
   -- Primary Work Domains
+  { '<leader>a', group = 'AI', icon = icons.ai, mode = 'n' },
+  { '<leader>as', group = 'AI', icon = icons.ai, mode = 'v' },
   { '<leader>b', group = 'buffers', icon = icons.buffer, mode = { 'n', 'v' } },
   { '<leader>c', group = 'code', icon = icons.code, mode = { 'n', 'v' } },
   { '<leader>e', group = 'errors', icon = icons.error, mode = { 'n', 'v' } },


### PR DESCRIPTION
## Summary
- Add `<leader>a` AI domain with comprehensive keybinding integration for Claude Code functionality
- Implement 5 core keybindings following established core.nix patterns and progressive disclosure design
- Update documentation and which-key integration with proper mode scoping

## Test plan
- [ ] Apply configuration changes with `home-manager switch`
- [ ] Verify AI domain appears in which-key with `<leader>` 
- [ ] Test `<leader>aa` for terminal focus behavior
- [ ] Test `<leader>as` in both normal and visual modes
- [ ] Test diff accept/reject commands during Claude Code sessions
- [ ] Verify model selection picker functionality

🤖 Generated with [Claude Code](https://claude.ai/code)