### PR TITLE
Add FiraCode nerd font

### DIFF
--- a/nix-darwin/fonts/default.nix
+++ b/nix-darwin/fonts/default.nix
@@ -5,6 +5,7 @@
 {
   fonts.packages = with pkgs; [
     nerd-fonts.victor-mono
+    nerd-fonts.fira-code
   ];
 }
 


### PR DESCRIPTION
## Summary
- Add FiraCode nerd font to system fonts
- Complements existing VictorMono font
- Provides programming ligatures and icons

## Test plan
- [ ] Verify font installs on macOS
- [ ] Check font appears in font selection dialogs
- [ ] Test ligatures in code editors

🤖 Generated with [Claude Code](https://claude.ai/code)