### PR TITLE
Remove Custom Icon Styling From Ghostty Configuration

### DIFF
--- a/home-manager/ghostty/config
+++ b/home-manager/ghostty/config
@@ -21,10 +21,6 @@ quit-after-last-window-closed = true
 macos-option-as-alt = true
 macos-window-shadow = true
 macos-titlebar-style = hidden
-macos-icon = custom-style
-macos-icon-frame = aluminum
-macos-icon-ghost-color = green
-macos-icon-screen-color = green
 
 # Clipboard
 clipboard-read = allow


### PR DESCRIPTION
## 🎯 What We're Doing

We're removing the custom icon styling configuration from Ghostty terminal emulator settings to simplify the configuration and rely on default system styling.

## 💡 Why This Matters

Custom icon styling in terminal applications can create visual inconsistency with system themes and may not provide significant user value. By removing these customizations, we reduce configuration complexity and ensure better integration with macOS appearance settings.

The removed styling includes:
- Custom icon style override
- Aluminum frame styling  
- Green color theming for ghost and screen elements

## ⚠️ Review Checklist

- 🔍 **Configuration Removal**: Verify all icon-related settings are properly removed → No visual artifacts or broken references
- 🔍 **Default Behavior**: Confirm Ghostty falls back to appropriate system defaults → Maintains professional appearance

## 🔧 Technical Approach

Chose to remove all custom icon styling rather than updating to different values because system defaults provide better consistency across different macOS themes and reduce maintenance overhead for appearance-related configuration.

🤖 Generated with [Claude Code](https://claude.ai/code)