### PR TITLE
fix: resolve neovim TODOs and simplify claudecode configuration

### DIFF
--- a/home-manager/neovim/default.nix
+++ b/home-manager/neovim/default.nix
@@ -49,10 +49,6 @@
             rev = "v0.3.0";
             sha256 = "sha256-sOBY2y/buInf+SxLwz6uYlUouDULwebY/nmDlbFbGa8=";
           };
-          # Patch to make config options actually work.
-          patches = [
-            ./patches/claudecode-split.patch # Respect vertical_split setting
-          ];
         };
         type = "lua";
         config = builtins.readFile ./plugins/claudecode.lua;

--- a/home-manager/neovim/default.nix
+++ b/home-manager/neovim/default.nix
@@ -49,10 +49,10 @@
             rev = "v0.3.0";
             sha256 = "sha256-sOBY2y/buInf+SxLwz6uYlUouDULwebY/nmDlbFbGa8=";
           };
-          # Patch to make config options actually work - TODO: see if this is no longer needed.
-          # patches = [
-          #   ./patches/claudecode-split.patch # Respect vertical_split setting
-          # ];
+          # Patch to make config options actually work.
+          patches = [
+            ./patches/claudecode-split.patch # Respect vertical_split setting
+          ];
         };
         type = "lua";
         config = builtins.readFile ./plugins/claudecode.lua;

--- a/home-manager/neovim/default.nix
+++ b/home-manager/neovim/default.nix
@@ -40,16 +40,7 @@
       }
       # Seamless integration with Claude Code.
       {
-        plugin = pkgs.vimUtils.buildVimPlugin {
-          pname = "claudecode-nvim";
-          version = "2024-12-15";
-          src = pkgs.fetchFromGitHub {
-            owner = "coder";
-            repo = "claudecode.nvim";
-            rev = "v0.3.0";
-            sha256 = "sha256-sOBY2y/buInf+SxLwz6uYlUouDULwebY/nmDlbFbGa8=";
-          };
-        };
+        plugin = claudecode-nvim;
         type = "lua";
         config = builtins.readFile ./plugins/claudecode.lua;
       }

--- a/home-manager/neovim/default.nix
+++ b/home-manager/neovim/default.nix
@@ -32,12 +32,12 @@
     ];
 
     plugins = with pkgs.vimPlugins; [
-      # A code outline window for skimming and quick navigation. - TODO: FIXME!!
-      # {
-      #   plugin = aerial-nvim;
-      #   type = "lua";
-      #   config = builtins.readFile ./plugins/aerial.lua;
-      # }
+      # A code outline window for skimming and quick navigation.
+      {
+        plugin = aerial-nvim;
+        type = "lua";
+        config = builtins.readFile ./plugins/aerial.lua;
+      }
       # Seamless integration with Claude Code.
       {
         plugin = pkgs.vimUtils.buildVimPlugin {

--- a/home-manager/neovim/plugins/claudecode.lua
+++ b/home-manager/neovim/plugins/claudecode.lua
@@ -2,7 +2,7 @@ local claudecode = require('claudecode')
 
 claudecode.setup({
   diff_opts = {
-    vertical_split = false, -- Use horizontal splits for better width in Zellij (default: true)
+    layout = "horizontal",
   },
   terminal = {
     split_side = 'left',


### PR DESCRIPTION
## Summary
- Enable aerial-nvim plugin for code outline functionality
- Update claudecode configuration to use native horizontal layout API
- Replace custom vimUtils.buildVimPlugin with nixpkgs claudecode-nvim package

## Changes
- **aerial-nvim**: Uncommented plugin configuration - provides code outline window
- **claudecode**: Updated from `vertical_split = false` to `layout = "horizontal"` (new API)
- **claudecode**: Switched from custom build to nixpkgs package (available since 2025-09-15)

## Test plan
- [x] Build succeeds with aerial-nvim enabled
- [x] Build succeeds with claudecode using new API (no patch needed)
- [x] Build succeeds with nixpkgs claudecode-nvim package
- [x] Configuration applies successfully via home-manager

🤖 Generated with [Claude Code](https://claude.ai/code)