### PR TITLE
feat: add OpenCode AI coding assistant integration

### DIFF
--- a/home-manager/default.nix
+++ b/home-manager/default.nix
@@ -20,6 +20,7 @@
     ./lsd
     ./neovim
     ./nixfmt
+    ./opencode
     ./openssl
     ./ripgrep
     ./telnet

--- a/home-manager/neovim/default.nix
+++ b/home-manager/neovim/default.nix
@@ -138,6 +138,12 @@
         type = "lua";
         config = builtins.readFile ./plugins/oil.lua;
       }
+      # Integration with OpenCode AI coding assistant.
+      {
+        plugin = opencode-nvim;
+        type = "lua";
+        config = builtins.readFile ./plugins/opencode.lua;
+      }
       # Asynchronous utilities for writing neovim LUA.
       plenary-nvim
       # The Refactoring library based off the refactoring book by Martin Fowler.

--- a/home-manager/neovim/plugins/opencode.lua
+++ b/home-manager/neovim/plugins/opencode.lua
@@ -1,0 +1,10 @@
+vim.g.opencode_opts = {
+  terminal = {
+    win = {
+      position = 'left',
+      enter = false,
+    },
+    auto_close = false,
+  },
+}
+

--- a/home-manager/opencode/default.nix
+++ b/home-manager/opencode/default.nix
@@ -1,0 +1,6 @@
+{ ... }:
+{
+  programs.opencode = {
+    enable = true;
+  };
+}

--- a/home-manager/opencode/default.nix
+++ b/home-manager/opencode/default.nix
@@ -2,5 +2,10 @@
 {
   programs.opencode = {
     enable = true;
+    settings = {
+      autoupdate = false;
+      theme = "gruvbox";
+    };
   };
 }
+


### PR DESCRIPTION
## Summary
- Add opencode program support via home-manager with gruvbox theme and disabled autoupdate
- Configure opencode.nvim plugin integration with terminal positioned on left side
- Add opencode module to home-manager imports

## Changes
- Added `home-manager/opencode/default.nix` with OpenCode program configuration
- Added `home-manager/neovim/plugins/opencode.lua` with nvim plugin configuration  
- Updated `home-manager/default.nix` to import opencode module
- Updated `home-manager/neovim/default.nix` to include opencode-nvim plugin

🤖 Generated with [Claude Code](https://claude.ai/code)