### PR TITLE
feat: add wallpapers flake input and output

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -1,11 +1,16 @@
 {
   description = "Opinionated Core Nix Configuration";
 
+  inputs = {
+    wallpapers.url = "github:Jitsusama/wallpapers.nix";
+  };
+
   outputs =
-    { ... }:
+    { wallpapers, ... }:
     {
       nix-darwin = ./nix-darwin;
       home-manager = ./home-manager;
+      wallpapers = wallpapers;
     };
 }
 


### PR DESCRIPTION
Adds wallpapers.nix as an input and re-exports it as an output, allowing downstream flakes to access the wallpaper collection through core.wallpapers.

This enables both work and personal configurations to use the same wallpaper collection while maintaining separation of concerns.