### PR TITLE
feat: add wallpaper support to Ghostty config

### DIFF
--- a/home-manager/ghostty/config
+++ b/home-manager/ghostty/config
@@ -6,9 +6,13 @@ font-size = 14
 font-family = MonaspiceXe Nerd Font
 
 # Window settings
-background-opacity = 0.90
+background = 000A00
+background-image = WALLPAPER_PATH
+background-image-fit = contain
+background-image-repeat = true
+background-image-opacity = 0.40
+background-opacity = 1.00
 unfocused-split-opacity = 0.77
-background-blur = 20
 window-height = 40
 window-width = 180
 window-padding-x = 6

--- a/home-manager/ghostty/default.nix
+++ b/home-manager/ghostty/default.nix
@@ -1,6 +1,7 @@
-{ ... }:
+{ lib, wallpapers, ... }:
 {
-  xdg.configFile = {
-    "ghostty/config".source = ./config;
-  };
+  xdg.configFile."ghostty/config".text = builtins.replaceStrings
+    [ "WALLPAPER_PATH" ]
+    [ "${wallpapers.tiles}/baroque-ornate-charcoal.png" ]
+    (builtins.readFile ./config);
 }


### PR DESCRIPTION
Adds wallpaper support to the Ghostty terminal configuration.

- Updated static config with background image settings
- Uses WALLPAPER_PATH placeholder that gets replaced at build time
- Module automatically uses baroque-ornate-charcoal.png from wallpapers flake
- Keeps all settings in the static config file for easy maintenance

The wallpaper path is injected dynamically, allowing different configurations to use different wallpapers while maintaining a single source of truth for all other settings.