### PR TITLE
feat: add flake.lock for deterministic dependencies

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,26 @@
+{
+  "nodes": {
+    "root": {
+      "inputs": {
+        "wallpapers": "wallpapers"
+      }
+    },
+    "wallpapers": {
+      "locked": {
+        "lastModified": 1759889113,
+        "narHash": "sha256-jzfSApNJ/64BuRZpOHHJDogWPm1Zyff4ipNF3NfBRBo=",
+        "owner": "Jitsusama",
+        "repo": "wallpapers.nix",
+        "rev": "9a4c725e3a1c8be6dd30768512b6a3684a260f3c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "Jitsusama",
+        "repo": "wallpapers.nix",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}


### PR DESCRIPTION
Adds flake.lock to ensure deterministic versions of dependencies.

## Problem
Without a flake.lock, downstream consumers control the version of wallpapers.nix, which could lead to:
- Build failures if expected wallpaper files don't exist in older versions
- Non-deterministic configurations across different consumers
- Unexpected breakage when wallpapers.nix changes

## Solution
Pin the exact version of wallpapers.nix that core.nix was tested with. This ensures:
- The ghostty module always has access to baroque-ornate-charcoal.png
- All consumers get the same, tested configuration
- Updates to wallpapers are controlled and tested in core.nix first

Downstream consumers can still override if needed using `inputs.core.inputs.wallpapers.follows`.