### PR TITLE
Enable Kitty Keyboard Protocol in WezTerm

### DIFF
--- a/home-manager/wezterm/wezterm.lua
+++ b/home-manager/wezterm/wezterm.lua
@@ -47,6 +47,9 @@ config.inactive_pane_hsb = {
 -- Cursor
 config.default_cursor_style = "SteadyBlock"
 
+-- Keyboard
+config.enable_kitty_keyboard = true
+
 -- Scrollback
 config.scrollback_lines = 10000
 


### PR DESCRIPTION
### 🔍 What We're Doing

Enabling the Kitty keyboard protocol in wezterm so that terminal applications which depend on it receive correct key input.

### 💡 Why This Matters

WezTerm defaults to legacy xterm encoding, which can't properly represent some ctrl key combinations. Tools like pi that use the Kitty keyboard protocol won't receive correct input without this opt-in, leading to broken keybindings.

### 🔧 How It Works

Single config line: `config.enable_kitty_keyboard = true`. This is WezTerm's opt-in to the [Kitty keyboard protocol](https://sw.kovidgoyal.net/kitty/keyboard-protocol/), which provides unambiguous key reporting to applications that request it.
