### PR TITLE
Ignore Transient Pi Directory Contents Globally

### DIFF
--- a/home-manager/git/default.nix
+++ b/home-manager/git/default.nix
@@ -35,6 +35,11 @@
       "*.DS_Store"
       ".bundle/config"
       ".worktrees/"
+      ".pi/*"
+      "!.pi/extensions/"
+      "!.pi/prompts/"
+      "!.pi/skills/"
+      "!.pi/themes/"
     ];
   };
 }


### PR DESCRIPTION
### 🔍 What We're Doing

Adding global gitignore rules so `.pi/` directory contents are ignored by default across all repositories, while preserving project-shareable pi configuration like extensions, skills, prompts and themes.

### 💡 Why This Matters

Without this, every repository that uses pi accumulates transient files (plans, agent state, session data) in the working tree that show up in `git status` and risk being accidentally committed. These files are personal working artifacts, not project configuration.

### 🔧 How It Works

The pattern `.pi/*` ignores everything inside `.pi/`, then negations (`!.pi/extensions/`, etc.) carve out the subdirectories that represent intentional, shareable project configuration. This means extensions, skills, prompts and themes can still be tracked normally while plans, scripts and other transient content stays out of version control.

---
*Co-Authored-By AI (Claude Opus 4.6) via [Pi](https://github.com/badlogic/pi-mono)*
