### PR TITLE
Fix Gitignore Patterns to Match at Any Directory Depth

### DIFF
--- a/home-manager/git/default.nix
+++ b/home-manager/git/default.nix
@@ -34,6 +34,7 @@
       "*.iml"
       "*.DS_Store"
       ".bundle/config"
+      ".review/"
       ".worktrees/"
       ".pi/*"
       "!.pi/extensions/"

--- a/home-manager/git/default.nix
+++ b/home-manager/git/default.nix
@@ -33,14 +33,14 @@
       "*.idea/"
       "*.iml"
       "*.DS_Store"
-      ".bundle/config"
+      "**/.bundle/config"
       ".review/"
       ".worktrees/"
-      ".pi/*"
-      "!.pi/extensions/"
-      "!.pi/prompts/"
-      "!.pi/skills/"
-      "!.pi/themes/"
+      "**/.pi/*"
+      "!**/.pi/extensions/"
+      "!**/.pi/prompts/"
+      "!**/.pi/skills/"
+      "!**/.pi/themes/"
     ];
   };
 }


### PR DESCRIPTION
### 🔍 What We're Doing

Prefixing gitignore patterns that contain mid-path slashes (`.pi/*` and `.bundle/config`) with `**/` so they match at any directory depth instead of being anchored to the repo root.

### 💡 Why This Matters

Gitignore treats any pattern with a slash in the beginning or middle as relative to the repository root. In monorepo worktrees (like `shop/world`) where the working directory is a subdirectory, patterns like `.pi/*` silently fail to match because the actual path is something like `system/gitstream/.pi/*`. This leaves `.pi/` directories showing up as untracked with no obvious explanation.

Patterns without a mid-path slash (`.vscode/`, `*.DS_Store`, `.review/`) already match at any depth, so they weren't affected.

### 🔧 How It Works

The `**/` prefix tells gitignore to match the rest of the pattern at any directory level. The negation patterns for `.pi/extensions/`, `.pi/prompts/`, `.pi/skills/` and `.pi/themes/` get the same prefix so they continue to override the base ignore correctly.

---
*Co-Authored-By AI (Claude Opus 4.6) via [Pi](https://github.com/badlogic/pi-mono)*
