### PR TITLE
Remove Tab Arrow From Neovim Listchars

### DIFF
--- a/home-manager/neovim/init.lua
+++ b/home-manager/neovim/init.lua
@@ -25,7 +25,6 @@ vim.opt.ruler = false -- Don't show cursor position in command line
 -- Better list characters
 vim.opt.list = true
 vim.opt.listchars = {
-  tab = '→ ',
   trail = '·',
   extends = '❯',
   precedes = '❮',


### PR DESCRIPTION
### 🔍 What We're Doing

Removing the `tab = '→ '` entry from the Neovim `listchars` configuration so tab characters render as normal whitespace instead of arrow symbols.

### 💡 Why This Matters

Source code that uses tabs for indentation (e.g., Go) becomes cluttered with arrow characters at every indentation level, making it harder to read. The other listchars — trailing spaces, overflow indicators and non-breaking spaces — are preserved since they flag genuinely invisible issues worth seeing.

### 🔧 How It Works

Single-line removal from the `listchars` table in `init.lua`. Neovim's default tab rendering (plain whitespace) takes over.

---
*Co-Authored-By AI (Claude Opus 4.6) via [Pi](https://github.com/badlogic/pi-mono)*
