### PR TITLE
Render Tabs as Plain Whitespace in Neovim Listchars

### DIFF
--- a/home-manager/neovim/init.lua
+++ b/home-manager/neovim/init.lua
@@ -25,6 +25,7 @@ vim.opt.ruler = false -- Don't show cursor position in command line
 -- Better list characters
 vim.opt.list = true
 vim.opt.listchars = {
+  tab = '  ',
   trail = '·',
   extends = '❯',
   precedes = '❮',


### PR DESCRIPTION
### 🔍 What We're Doing

Adding `tab = '  '` (two spaces) to the Neovim `listchars` configuration so tab characters render as plain whitespace instead of `^I` control characters.

### 💡 Why This Matters

The previous commit removed the `tab = '→ '` arrow entry to declutter tab-indented source code (e.g., Go). However, without any `tab` entry in `listchars`, Neovim falls back to displaying `^I` for every tab — which is worse. Setting the tab characters to spaces makes tabs invisible while still respecting the `tabstop` width dynamically.

### 🔧 How It Works

Neovim's `tab:xy` listchar uses the first character once, then repeats the second character to fill to the next tabstop column. Two spaces means tabs render as plain whitespace at whatever width `tabstop` dictates.

---
*Co-Authored-By AI (Claude Opus 4.6) via [Pi](https://github.com/badlogic/pi-mono)*
